### PR TITLE
OPD-2240: Downgraded jettyVersion to 9.4.44.v20210927

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ scalaVersion=2.13.5
 kafkaVersion=3.7.1
 zookeeperVersion=3.8.4
 nettyVersion=4.1.100.Final
-jettyVersion=9.4.53.v20231009
+jettyVersion=9.4.44.v20210927
 vertxVersion=4.5.0


### PR DESCRIPTION
We need no downgrade netty version to make cruise-control3 UI  compatible with kafka-3.7.1.

This patch was tested locally