### PR TITLE
OSV-23171 - CVE - Bumped-up Log4j to 2.25.4 to address CVE-2026-34478

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,7 +181,7 @@ project(':cruise-control-core') {
       exclude group: 'log4j', module: 'log4j'
     }
     implementation "org.slf4j:slf4j-api:1.7.36"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.3"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.4"
     implementation 'org.apache.commons:commons-math3:3.6.1'
     api "org.eclipse.jetty:jetty-servlet:${jettyVersion}"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
@@ -284,7 +284,7 @@ project(':cruise-control') {
     api project(':cruise-control-metrics-reporter')
     api project(':cruise-control-core')
     implementation "org.slf4j:slf4j-api:1.7.36"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.3"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.4"
     implementation "org.apache.zookeeper:zookeeper:${zookeeperVersion}"
     implementation "io.netty:netty-handler:${nettyVersion}"
     implementation "io.netty:netty-transport-native-epoll:${nettyVersion}"
@@ -452,7 +452,7 @@ project(':cruise-control-metrics-reporter') {
 
     implementation "org.slf4j:slf4j-api:1.7.36"
     implementation "com.yammer.metrics:metrics-core:2.2.0"
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.3"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:2.25.4"
     implementation "org.apache.kafka:kafka_$scalaBinaryVersion:$kafkaVersion"
     implementation "org.apache.kafka:kafka-clients:$kafkaVersion"
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
- Library : Log4j
- Version : -> 2.25.4
- Tickets : OSV-23171, OSV-23172, OSV-23173, OSV-23174, OSV-23175