### PR TITLE
OSV-23170 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ allprojects {
   configurations.all {
      resolutionStrategy {
        force 'org.slf4j:slf4j-api:1.7.36'
+       force 'org.apache.commons:commons-lang3:3.18.0'
      }
    }
 


### PR DESCRIPTION
- Component: cruise-control3 (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-lang3 → 3.18.0
- Tickets: OSV-23170
- Files: build.gradle