### PR TITLE
OSV-23186 - CVE - Bumped-up nimbus-jose-jwt to 10.0.2 to address CVE-2025-53864

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,7 +299,7 @@ project(':cruise-control') {
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation "org.eclipse.jetty:jetty-server:${jettyVersion}"
     implementation 'io.dropwizard.metrics:metrics-jmx:4.2.9'
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation 'io.swagger.parser.v3:swagger-parser-v3:2.1.16'
     implementation 'io.github.classgraph:classgraph:4.8.141'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'


### PR DESCRIPTION
- Component: cruise-control3 (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: nimbus-jose-jwt → 10.0.2
- Tickets: OSV-23186
- Files: build.gradle