### PR TITLE
OSV-23176 - CVE - Bumped-up vertx to 4.5.24 to address CVE-2024-1023/CVE-2024-1300/CVE-2025-11965/CVE-2025-11966/CVE-2026-1002

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ kafkaVersion=3.7.2.3.3.6.5-SNAPSHOT
 zookeeperVersion=3.8.4.3.3.6.5-SNAPSHOT
 nettyVersion=4.1.130.Final
 jettyVersion=9.4.58.v20250814
-vertxVersion=4.5.0
+vertxVersion=4.5.24


### PR DESCRIPTION
- Component: cruise-control3 (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: vertx → 4.5.24
- Tickets: OSV-23176, OSV-23177, OSV-23178, OSV-23181, OSV-23182
- Files: gradle.properties